### PR TITLE
Replace obsolete MANIFEST with MANIFEST.in

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,5 +1,0 @@
-httpauth.py
-setup.py
-test_httpauth.py
-README.rst
-Makefile

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include Makefile
+include test_httpauth.py


### PR DESCRIPTION
Replace the obsolete `MANIFEST` file with the more modern `MANIFEST.in`. The former is not supported by setuptools, and therefore the files listed in it were not included in sdist.

Fixes #6.